### PR TITLE
Fix authentication issue in transfer script

### DIFF
--- a/cdp-agentkit-core/cdp_agentkit_core/actions/transfer.py
+++ b/cdp-agentkit-core/cdp_agentkit_core/actions/transfer.py
@@ -13,6 +13,7 @@ It takes the following inputs:
 - assetId: The asset ID to transfer
 - destination: Where to send the funds (can be an onchain address, ENS 'example.eth', or Basename 'example.base.eth')
 - gasless: Whether to do a gasless transfer
+- auth_token: Optional authentication token for the transfer
 
 Important notes:
 - Gasless transfers are only available on base-sepolia and base-mainnet (base) networks for 'usdc' asset
@@ -40,10 +41,14 @@ class TransferInput(BaseModel):
         default=False,
         description="whether to do a gasless transfer (gasless is available on Base Sepolia and Mainnet for USDC) Always do the gasless option when it is available.",
     )
+    auth_token: str | None = Field(
+        default=None,
+        description="Optional authentication token for the transfer.",
+    )
 
 
 def transfer(
-    wallet: Wallet, amount: str, asset_id: str, destination: str, gasless: bool = False
+    wallet: Wallet, amount: str, asset_id: str, destination: str, gasless: bool = False, auth_token: str | None = None
 ) -> str:
     """Transfer a specified amount of an asset to a destination onchain. USDC Transfers on Base Sepolia and Mainnet can be gasless. Always use the gasless option when available.
 
@@ -53,14 +58,16 @@ def transfer(
         asset_id (str): The asset ID to transfer (e.g., "eth", "usdc", or a valid contract address like "0x036CbD53842c5426634e7929541eC2318f3dCF7e").
         destination (str): The destination to transfer the funds (e.g. `0x58dBecc0894Ab4C24F98a0e684c989eD07e4e027`, `example.eth`, `example.base.eth`).
         gasless (bool): Whether to send a gasless transfer (Defaults to False.).
+        auth_token (str | None): Optional authentication token for the transfer.
 
     Returns:
         str: A message containing the transfer details.
 
     """
     try:
+        headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
         transfer_result = wallet.transfer(
-            amount=amount, asset_id=asset_id, destination=destination, gasless=gasless
+            amount=amount, asset_id=asset_id, destination=destination, gasless=gasless, headers=headers
         ).wait()
     except Exception as e:
         return f"Error transferring the asset {e!s}"

--- a/cdp-agentkit-core/tests/actions/test_transfer.py
+++ b/cdp-agentkit-core/tests/actions/test_transfer.py
@@ -11,6 +11,7 @@ MOCK_AMOUNT = "0.01"
 MOCK_ASSET_ID = "usdc"
 MOCK_DESTINATION = "example.eth"
 MOCK_GASLESS = True
+MOCK_AUTH_TOKEN = "mock_auth_token"
 
 
 def test_transfer_input_model_valid():
@@ -20,12 +21,14 @@ def test_transfer_input_model_valid():
         asset_id=MOCK_ASSET_ID,
         destination=MOCK_DESTINATION,
         gasless=MOCK_GASLESS,
+        auth_token=MOCK_AUTH_TOKEN,
     )
 
     assert input_model.amount == MOCK_AMOUNT
     assert input_model.asset_id == MOCK_ASSET_ID
     assert input_model.destination == MOCK_DESTINATION
     assert input_model.gasless is MOCK_GASLESS
+    assert input_model.auth_token == MOCK_AUTH_TOKEN
 
 
 def test_transfer_input_model_missing_params():
@@ -46,7 +49,7 @@ def test_transfer_success(wallet_factory, transfer_factory):
         ) as mock_transfer_wait,
     ):
         action_response = transfer(
-            mock_wallet, MOCK_AMOUNT, MOCK_ASSET_ID, MOCK_DESTINATION, MOCK_GASLESS
+            mock_wallet, MOCK_AMOUNT, MOCK_ASSET_ID, MOCK_DESTINATION, MOCK_GASLESS, MOCK_AUTH_TOKEN
         )
 
         expected_response = f"Transferred {MOCK_AMOUNT} of {MOCK_ASSET_ID} to {MOCK_DESTINATION}.\nTransaction hash for the transfer: {mock_transfer_instance.transaction_hash}\nTransaction link for the transfer: {mock_transfer_instance.transaction_link}"
@@ -56,6 +59,7 @@ def test_transfer_success(wallet_factory, transfer_factory):
             asset_id=MOCK_ASSET_ID,
             destination=MOCK_DESTINATION,
             gasless=MOCK_GASLESS,
+            headers={"Authorization": f"Bearer {MOCK_AUTH_TOKEN}"},
         )
         mock_transfer_wait.assert_called_once_with()
 
@@ -66,7 +70,7 @@ def test_transfer_api_error(wallet_factory):
 
     with patch.object(mock_wallet, "transfer", side_effect=Exception("API error")) as mock_transfer:
         action_response = transfer(
-            mock_wallet, MOCK_AMOUNT, MOCK_ASSET_ID, MOCK_DESTINATION, MOCK_GASLESS
+            mock_wallet, MOCK_AMOUNT, MOCK_ASSET_ID, MOCK_DESTINATION, MOCK_GASLESS, MOCK_AUTH_TOKEN
         )
 
         expected_response = "Error transferring the asset API error"
@@ -77,4 +81,32 @@ def test_transfer_api_error(wallet_factory):
             asset_id=MOCK_ASSET_ID,
             destination=MOCK_DESTINATION,
             gasless=MOCK_GASLESS,
+            headers={"Authorization": f"Bearer {MOCK_AUTH_TOKEN}"},
         )
+
+
+def test_transfer_without_auth_token(wallet_factory, transfer_factory):
+    """Test transfer without auth_token parameter."""
+    mock_wallet = wallet_factory()
+    mock_transfer_instance = transfer_factory()
+
+    with (
+        patch.object(mock_wallet, "transfer", return_value=mock_transfer_instance) as mock_transfer,
+        patch.object(
+            mock_transfer_instance, "wait", return_value=mock_transfer_instance
+        ) as mock_transfer_wait,
+    ):
+        action_response = transfer(
+            mock_wallet, MOCK_AMOUNT, MOCK_ASSET_ID, MOCK_DESTINATION, MOCK_GASLESS
+        )
+
+        expected_response = f"Transferred {MOCK_AMOUNT} of {MOCK_ASSET_ID} to {MOCK_DESTINATION}.\nTransaction hash for the transfer: {mock_transfer_instance.transaction_hash}\nTransaction link for the transfer: {mock_transfer_instance.transaction_link}"
+        assert action_response == expected_response
+        mock_transfer.assert_called_once_with(
+            amount=MOCK_AMOUNT,
+            asset_id=MOCK_ASSET_ID,
+            destination=MOCK_DESTINATION,
+            gasless=MOCK_GASLESS,
+            headers={},
+        )
+        mock_transfer_wait.assert_called_once_with()


### PR DESCRIPTION
Add `auth_token` parameter to the `transfer` function to accept an authentication token.

* **cdp-agentkit-core/cdp_agentkit_core/actions/transfer.py**
  - Add `auth_token` parameter to the `transfer` function.
  - Update the `TransferInput` model to include an optional `auth_token` field.
  - Include the `auth_token` parameter in the API request headers.

* **cdp-agentkit-core/tests/actions/test_transfer.py**
  - Add a new test case to verify the `auth_token` parameter is correctly passed to the `transfer` function.
  - Update existing test cases to include the `auth_token` parameter where necessary.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Setland34/cdp-agentkit/pull/1?shareId=d3ece07d-39d3-4fea-b6e5-b94cbb40020b).