### PR TITLE
Add ETH transfer functionality

### DIFF
--- a/cdp-agentkit-core/cdp_agentkit_core/actions/transfer.py
+++ b/cdp-agentkit-core/cdp_agentkit_core/actions/transfer.py
@@ -68,6 +68,28 @@ def transfer(
     return f"Transferred {amount} of {asset_id} to {destination}.\nTransaction hash for the transfer: {transfer_result.transaction_hash}\nTransaction link for the transfer: {transfer_result.transaction_link}"
 
 
+def transfer_eth(wallet: Wallet, amount: str, destination: str) -> str:
+    """Transfer a specified amount of ETH to a destination onchain.
+
+    Args:
+        wallet (Wallet): The wallet to transfer the ETH from.
+        amount (str): The amount of ETH to transfer, e.g. `0.005`.
+        destination (str): The destination to transfer the ETH (e.g. `0x58dBecc0894Ab4C24F98a0e684c989eD07e4e027`, `example.eth`, `example.base.eth`).
+
+    Returns:
+        str: A message containing the transfer details.
+
+    """
+    try:
+        transfer_result = wallet.transfer(
+            amount=amount, asset_id="eth", destination=destination, gasless=False
+        ).wait()
+    except Exception as e:
+        return f"Error transferring ETH {e!s}"
+
+    return f"Transferred {amount} of ETH to {destination}.\nTransaction hash for the transfer: {transfer_result.transaction_hash}\nTransaction link for the transfer: {transfer_result.transaction_link}"
+
+
 class TransferAction(CdpAction):
     """Transfer action."""
 
@@ -75,3 +97,12 @@ class TransferAction(CdpAction):
     description: str = TRANSFER_PROMPT
     args_schema: type[BaseModel] | None = TransferInput
     func: Callable[..., str] = transfer
+
+
+class TransferEthAction(CdpAction):
+    """Transfer ETH action."""
+
+    name: str = "transfer_eth"
+    description: str = "This tool will transfer ETH from the wallet to another onchain address."
+    args_schema: type[BaseModel] | None = TransferInput
+    func: Callable[..., str] = transfer_eth

--- a/cdp-agentkit-core/tests/actions/test_transfer.py
+++ b/cdp-agentkit-core/tests/actions/test_transfer.py
@@ -5,12 +5,16 @@ import pytest
 from cdp_agentkit_core.actions.transfer import (
     TransferInput,
     transfer,
+    transfer_eth,
 )
 
 MOCK_AMOUNT = "0.01"
 MOCK_ASSET_ID = "usdc"
 MOCK_DESTINATION = "example.eth"
 MOCK_GASLESS = True
+
+MOCK_ETH_AMOUNT = "0.005"
+MOCK_ETH_DESTINATION = "john2879.base.eth"
 
 
 def test_transfer_input_model_valid():
@@ -77,4 +81,50 @@ def test_transfer_api_error(wallet_factory):
             asset_id=MOCK_ASSET_ID,
             destination=MOCK_DESTINATION,
             gasless=MOCK_GASLESS,
+        )
+
+
+def test_transfer_eth_success(wallet_factory, transfer_factory):
+    """Test successful ETH transfer with valid parameters."""
+    mock_wallet = wallet_factory()
+    mock_transfer_instance = transfer_factory()
+
+    with (
+        patch.object(mock_wallet, "transfer", return_value=mock_transfer_instance) as mock_transfer,
+        patch.object(
+            mock_transfer_instance, "wait", return_value=mock_transfer_instance
+        ) as mock_transfer_wait,
+    ):
+        action_response = transfer_eth(
+            mock_wallet, MOCK_ETH_AMOUNT, MOCK_ETH_DESTINATION
+        )
+
+        expected_response = f"Transferred {MOCK_ETH_AMOUNT} of ETH to {MOCK_ETH_DESTINATION}.\nTransaction hash for the transfer: {mock_transfer_instance.transaction_hash}\nTransaction link for the transfer: {mock_transfer_instance.transaction_link}"
+        assert action_response == expected_response
+        mock_transfer.assert_called_once_with(
+            amount=MOCK_ETH_AMOUNT,
+            asset_id="eth",
+            destination=MOCK_ETH_DESTINATION,
+            gasless=False,
+        )
+        mock_transfer_wait.assert_called_once_with()
+
+
+def test_transfer_eth_api_error(wallet_factory):
+    """Test ETH transfer when API error occurs."""
+    mock_wallet = wallet_factory()
+
+    with patch.object(mock_wallet, "transfer", side_effect=Exception("API error")) as mock_transfer:
+        action_response = transfer_eth(
+            mock_wallet, MOCK_ETH_AMOUNT, MOCK_ETH_DESTINATION
+        )
+
+        expected_response = "Error transferring ETH API error"
+
+        assert action_response == expected_response
+        mock_transfer.assert_called_once_with(
+            amount=MOCK_ETH_AMOUNT,
+            asset_id="eth",
+            destination=MOCK_ETH_DESTINATION,
+            gasless=False,
         )


### PR DESCRIPTION
Add functionality for ETH transfers and corresponding tests.

* **cdp-agentkit-core/cdp_agentkit_core/actions/transfer.py**
  - Add `transfer_eth` function to handle ETH transfers.
  - Update `TransferAction` class to include a new action for ETH transfers with `TransferEthAction`.

* **cdp-agentkit-core/tests/actions/test_transfer.py**
  - Add `test_transfer_eth_success` to test successful ETH transfers.
  - Add `test_transfer_eth_api_error` to test ETH transfer API errors.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Setland34/cdp-agentkit/pull/2?shareId=905da986-5fbd-432c-bd50-8232c0385042).